### PR TITLE
glycin - nix build for libglycin and libglycin-gtk

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,8 +44,12 @@
           vala
           vala-lint
         ];
+        local-libs = with self.packages.${system}; [
+          libglycin
+        ];
         system-libs = with pkgs; [
           glib
+          glycin-loaders
           gtk4
           gtk4-layer-shell
           libadwaita
@@ -69,6 +73,7 @@
             astal-libs
             ++ build-tools
             ++ compiler-tools
+            ++ local-libs
             ++ system-libs;
         };
 
@@ -77,10 +82,16 @@
             astal-libs
             ++ build-tools
             ++ compiler-tools
+            ++ local-libs
             ++ system-libs;
         };
+
+        libglycin-shim = pkgs.callPackage ./nix/libglycin/libglycin-shim.nix {};
+        libglycin = pkgs.callPackage ./nix/libglycin/libglycin.nix {inherit libglycin-shim;};
       in {
         packages.default = vanity;
+        packages.libglycin-shim = libglycin-shim;
+        packages.libglycin = libglycin;
         devShells.default = shell;
       }
     );

--- a/nix/libglycin/README.md
+++ b/nix/libglycin/README.md
@@ -1,0 +1,18 @@
+# Glycin - libglycin
+
+[glycin](https://gitlab.gnome.org/GNOME/glycin) is a rust library that sandboxes loading images into gdk testures. Only the loaders are currently packaged in nixpkgs (for consumption by the rust native client library). I want to use the client library in vala, so this builds libglycin and the vapi bindings. 
+
+## Build funkiness
+
+libglycin is required to build libglycin-gtk4. The meson.build for libglycin doesn't allow these to be built separately. There are some patches and workarounds to get around this along with some nix specific mitigations detailed below.
+
+### Patch details
+
+- ./fix-glycin-paths.patch
+  - Normal nix path fixes. Replaces the `bwrap` with a full nix store binary path, and modifies the cargo checksums to allow modifying vendored code.
+- ./glycin-shim.patch
+  - Prevents modifications to PKG_CONFIG_PATH.
+  - Builds only libglycin
+- ./fix-glycin-deps.patch
+  - Prevents modifications to PKG_CONFIG_PATH.
+  - Declares libglycin as a meson dependency to libglycin-gtk.

--- a/nix/libglycin/fix-glycin-deps.patch
+++ b/nix/libglycin/fix-glycin-deps.patch
@@ -1,0 +1,21 @@
+diff --git a/libglycin/meson.build b/libglycin/meson.build
+index 3192e06..6271aff 100644
+--- a/libglycin/meson.build
++++ b/libglycin/meson.build
+@@ -18,7 +18,7 @@ cargo_options = [
+     '--manifest-path', manifest,
+ ]
+ 
+-pkg_uninstalled_path = {'PKG_CONFIG_PATH': meson.project_build_root() / 'meson-uninstalled'}
++pkg_uninstalled_path = {}
+ 
+ cargo_env = {
+     'CARGO_HOME': cargo_home,
+@@ -35,7 +35,7 @@ packages = [
+         'suffix': '-gtk4',
+         'namespace_suffix': 'Gtk4',
+         'symbol_prefix_suffix': '_gtk',
+-        'extra_deps': [dependency('gtk4', version: gtk4_req)],
++        'extra_deps': [dependency('gtk4', version: gtk4_req), dependency('glycin-1')],
+     },
+ ]

--- a/nix/libglycin/fix-glycin-paths.patch
+++ b/nix/libglycin/fix-glycin-paths.patch
@@ -1,0 +1,33 @@
+diff --git a/vendor/glycin/.cargo-checksum.json b/vendor/glycin/.cargo-checksum.json
+index fa403e7..9db463b 100644
+--- a/vendor/glycin/.cargo-checksum.json
++++ b/vendor/glycin/.cargo-checksum.json
+@@ -1 +1 @@
+-{"files":{"Cargo.lock":"8f640d494c2c8cf8838b7f63fbee41f348a5495de22a08e9a3845834a7c1aea5","Cargo.toml":"606cd425f615a5828aac4f6812228c0c79260eb7a124b4571d31886bb4fb824f","LICENSE":"78dcffc5c141fab8667edb50a76ef6dbfb313884686cca7547a32f34138564eb","LICENSE-LGPL-2.1":"cdb29328127167b36d3dbb5de8ee0aab03cb8a473a725c465d89edbb8b9690ad","LICENSE-MPL-2.0":"3f3d9e0024b1921b067d6f7f88deb4a60cbe7a78e76c64e3f1d7fc3b779b9d04","README.md":"8969ebc8829551d1b10f7bd3d4a2ab7df912140360589ccadd7c1a12566532ed","examples/glycin-render.rs":"6186c21d705f553ff4badddee1e238969987dce63b7f0d8ef9aec01abbeb65c5","examples/glycin-rotate-cw.rs":"b22335437981f771ec3466c82ddac6bd7200ee3a061be483c881fb09d5d4dfb0","src/api_common.rs":"fd9717932c4068ee8bd06c64b0767a1dd9a7e83c47214a2d99fe413aede32850","src/api_editor.rs":"5d818c41a4dfd05e348db1fd2b0c4f5ce38491c4e21d3869bfb6b6afbc2da972","src/api_loader.rs":"4912e6620fe01acfbd4abeba7da5b35b99776fcadbbfe6705bbfd8ece5041296","src/config.rs":"9e4619f5749f7a9ee06f60e9dfc5c50c48825d3b4fc03576c574da7c8bf739f6","src/dbus.rs":"386df355ab27d02df3144c08cc97fd3ccf0889e3699ec015a1e000297bd12ad2","src/error.rs":"5c241adf15617c4f9201088f2b6526e515ae727b0b95693977145f86a2558388","src/fontconfig.rs":"cd2cbaeea556296d5187d94831aa39fea94bcd33d2cecb35760ac3455dd15005","src/gobject.rs":"3a89132c3565a8c66406a680ec686ada62fc1c2b0314db67f534797fdbca420c","src/gobject/frame.rs":"dcd365b9126d217640387a5f88a606a6f1ba6552af3810d1e5992e44d0ab31e2","src/gobject/image.rs":"54fe8ea0573f4be4948bc7d5840ee0a514c6a7517c7d328b8bc03988dc3f8822","src/gobject/loader.rs":"552c174cb80854f63f6513c7e40653c171ff274e7bed4bf7b43dffd030506ffc","src/icc.rs":"ad24fa13c44beb04599ccc4ceb979aed60a9267481920bf97babd115b506887f","src/lib.rs":"90e8ab16ca0f458231f80479e02171a295f871e6c45a79f60e96b923af6ee69f","src/orientation.rs":"233fd24fdb9fda15f23b5bef77f490f09dbca20d41e7b2872ed9f02decb4ee54","src/sandbox.rs":"66ec76b520cd8c427a559fc68a9fa58a7467c5a266443969287b216fc2a0a462","src/util.rs":"834ed8af11b283737dec3818981d2eb3d3441548026908959b0196012228c760"},"package":"a0c0c43ba80d02ea8cd540163e7cb49eced263fe3100c91c505acf5f9399ccb5"}
+\ No newline at end of file
++{"files":{"Cargo.lock":"8f640d494c2c8cf8838b7f63fbee41f348a5495de22a08e9a3845834a7c1aea5","Cargo.toml":"606cd425f615a5828aac4f6812228c0c79260eb7a124b4571d31886bb4fb824f","LICENSE":"78dcffc5c141fab8667edb50a76ef6dbfb313884686cca7547a32f34138564eb","LICENSE-LGPL-2.1":"cdb29328127167b36d3dbb5de8ee0aab03cb8a473a725c465d89edbb8b9690ad","LICENSE-MPL-2.0":"3f3d9e0024b1921b067d6f7f88deb4a60cbe7a78e76c64e3f1d7fc3b779b9d04","README.md":"8969ebc8829551d1b10f7bd3d4a2ab7df912140360589ccadd7c1a12566532ed","examples/glycin-render.rs":"6186c21d705f553ff4badddee1e238969987dce63b7f0d8ef9aec01abbeb65c5","examples/glycin-rotate-cw.rs":"b22335437981f771ec3466c82ddac6bd7200ee3a061be483c881fb09d5d4dfb0","src/api_common.rs":"fd9717932c4068ee8bd06c64b0767a1dd9a7e83c47214a2d99fe413aede32850","src/api_editor.rs":"5d818c41a4dfd05e348db1fd2b0c4f5ce38491c4e21d3869bfb6b6afbc2da972","src/api_loader.rs":"4912e6620fe01acfbd4abeba7da5b35b99776fcadbbfe6705bbfd8ece5041296","src/config.rs":"9e4619f5749f7a9ee06f60e9dfc5c50c48825d3b4fc03576c574da7c8bf739f6","src/dbus.rs":"386df355ab27d02df3144c08cc97fd3ccf0889e3699ec015a1e000297bd12ad2","src/error.rs":"5c241adf15617c4f9201088f2b6526e515ae727b0b95693977145f86a2558388","src/fontconfig.rs":"cd2cbaeea556296d5187d94831aa39fea94bcd33d2cecb35760ac3455dd15005","src/gobject.rs":"3a89132c3565a8c66406a680ec686ada62fc1c2b0314db67f534797fdbca420c","src/gobject/frame.rs":"dcd365b9126d217640387a5f88a606a6f1ba6552af3810d1e5992e44d0ab31e2","src/gobject/image.rs":"54fe8ea0573f4be4948bc7d5840ee0a514c6a7517c7d328b8bc03988dc3f8822","src/gobject/loader.rs":"552c174cb80854f63f6513c7e40653c171ff274e7bed4bf7b43dffd030506ffc","src/icc.rs":"ad24fa13c44beb04599ccc4ceb979aed60a9267481920bf97babd115b506887f","src/lib.rs":"90e8ab16ca0f458231f80479e02171a295f871e6c45a79f60e96b923af6ee69f","src/orientation.rs":"233fd24fdb9fda15f23b5bef77f490f09dbca20d41e7b2872ed9f02decb4ee54","src/sandbox.rs":"b558d24c7f4e394301dd34e90d99c840aa35c55a3c380fcd4ee548d8f39523ee","src/util.rs":"834ed8af11b283737dec3818981d2eb3d3441548026908959b0196012228c760"},"package":"a0c0c43ba80d02ea8cd540163e7cb49eced263fe3100c91c505acf5f9399ccb5"}
+\ No newline at end of file
+diff --git a/vendor/glycin/src/sandbox.rs b/vendor/glycin/src/sandbox.rs
+index d2d150d..d7cca83 100644
+--- a/vendor/glycin/src/sandbox.rs
++++ b/vendor/glycin/src/sandbox.rs
+@@ -202,7 +202,7 @@ impl Sandbox {
+ 
+                 args.push(self.exec());
+ 
+-                ("bwrap".into(), args, Some(seccomp_memfd))
++                ("@bwrap@".into(), args, Some(seccomp_memfd))
+             }
+             SandboxMechanism::FlatpakSpawn => {
+                 let memory_limit = Self::memory_limit();
+@@ -299,8 +299,8 @@ impl Sandbox {
+                 "/",
+                 // Make /usr available as read only
+                 "--ro-bind",
+-                "/usr",
+-                "/usr",
++                "/nix/store",
++                "/nix/store",
+                 // Make tmpfs dev available
+                 "--dev",
+                 "/dev",

--- a/nix/libglycin/glycin-shim.patch
+++ b/nix/libglycin/glycin-shim.patch
@@ -1,0 +1,26 @@
+diff --git a/libglycin/meson.build b/libglycin/meson.build
+index 3192e06..9f1cc65 100644
+--- a/libglycin/meson.build
++++ b/libglycin/meson.build
+@@ -18,7 +18,7 @@ cargo_options = [
+     '--manifest-path', manifest,
+ ]
+ 
+-pkg_uninstalled_path = {'PKG_CONFIG_PATH': meson.project_build_root() / 'meson-uninstalled'}
++pkg_uninstalled_path = {}
+ 
+ cargo_env = {
+     'CARGO_HOME': cargo_home,
+@@ -31,12 +31,6 @@ packages = [
+         'symbol_prefix_suffix': '',
+         'extra_deps': [],
+     },
+-    {
+-        'suffix': '-gtk4',
+-        'namespace_suffix': 'Gtk4',
+-        'symbol_prefix_suffix': '_gtk',
+-        'extra_deps': [dependency('gtk4', version: gtk4_req)],
+-    },
+ ]
+ 
+ foreach package : packages

--- a/nix/libglycin/libglycin-shim.nix
+++ b/nix/libglycin/libglycin-shim.nix
@@ -1,0 +1,94 @@
+# Adapted from https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/gl/glycin-loaders/package.nix#L79
+{
+  stdenv,
+  lib,
+  fetchurl,
+  replaceVars,
+  bubblewrap,
+  cairo,
+  cargo,
+  fontconfig,
+  git,
+  gobject-introspection,
+  gnome,
+  gtk4,
+  lcms2,
+  libheif,
+  libjxl,
+  librsvg,
+  libseccomp,
+  libxml2,
+  meson,
+  ninja,
+  pkg-config,
+  rustc,
+  vala,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libglycin";
+  version = "1.1.4";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/glycin/${lib.versions.majorMinor finalAttrs.version}/glycin-${finalAttrs.version}.tar.xz";
+    hash = "sha256-0bbVkLaZtmgaZ9ARmKWBp/cQ2Mp0UJNN1/XbJB+hJQA=";
+  };
+
+  patches = [
+    # Fix paths in glycin library.
+    finalAttrs.passthru.glycinPathsPatch
+    # Fix build bugs and only build libglycin, for use in next build
+    finalAttrs.passthru.glycinShimPatch
+  ];
+
+  nativeBuildInputs = [
+    cargo
+    git
+    meson
+    ninja
+    pkg-config
+    rustc
+    vala
+  ];
+
+  buildInputs = [
+    gtk4 # for GdkTexture
+    cairo
+    fontconfig
+    gobject-introspection
+    lcms2
+    libheif
+    libxml2 # for librsvg crate
+    librsvg
+    libseccomp
+    libjxl
+  ];
+
+  mesonFlags = [
+    "-Dglycin-loaders=true"
+    "-Dlibglycin=true"
+    "-Dvapi=true"
+  ];
+
+  passthru = {
+    updateScript = gnome.updateScript {
+      attrPath = "libglycin";
+      packageName = "glycin";
+    };
+
+    glycinPathsPatch = replaceVars ./fix-glycin-paths.patch {
+      bwrap = "${bubblewrap}/bin/bwrap";
+    };
+
+    glycinShimPatch = ./glycin-shim.patch;
+  };
+
+  meta = with lib; {
+    description = "libglycin with vapi";
+    homepage = "https://gitlab.gnome.org/GNOME/glycin";
+    license = with licenses; [
+      mpl20 # or
+      lgpl21Plus
+    ];
+    platforms = platforms.linux;
+  };
+})

--- a/nix/libglycin/libglycin.nix
+++ b/nix/libglycin/libglycin.nix
@@ -1,0 +1,96 @@
+# Adapted from https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/gl/glycin-loaders/package.nix#L79
+{
+  stdenv,
+  lib,
+  fetchurl,
+  replaceVars,
+  bubblewrap,
+  cairo,
+  cargo,
+  fontconfig,
+  git,
+  gobject-introspection,
+  gnome,
+  gtk4,
+  lcms2,
+  libglycin-shim,
+  libheif,
+  libjxl,
+  librsvg,
+  libseccomp,
+  libxml2,
+  meson,
+  ninja,
+  pkg-config,
+  rustc,
+  vala,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libglycin-gtk4";
+  version = "1.1.4";
+
+  src = fetchurl {
+    url = "mirror://gnome/sources/glycin/${lib.versions.majorMinor finalAttrs.version}/glycin-${finalAttrs.version}.tar.xz";
+    hash = "sha256-0bbVkLaZtmgaZ9ARmKWBp/cQ2Mp0UJNN1/XbJB+hJQA=";
+  };
+
+  patches = [
+    # Fix paths in glycin library.
+    finalAttrs.passthru.glycinPathsPatch
+    # Fix build bugs and add glycin-shim as dependency
+    finalAttrs.passthru.glycinDepsPatch
+  ];
+
+  nativeBuildInputs = [
+    cargo
+    git
+    meson
+    ninja
+    pkg-config
+    rustc
+    vala
+  ];
+
+  buildInputs = [
+    gtk4 # for GdkTexture
+    cairo
+    fontconfig
+    gobject-introspection
+    lcms2
+    libglycin-shim
+    libheif
+    libxml2 # for librsvg crate
+    librsvg
+    libseccomp
+    libjxl
+  ];
+
+  mesonFlags = [
+    "-Dglycin-loaders=true"
+    "-Dlibglycin=true"
+    "-Dvapi=true"
+  ];
+
+  passthru = {
+    updateScript = gnome.updateScript {
+      attrPath = "libglycin-gtk4";
+      packageName = "glycin";
+    };
+
+    glycinPathsPatch = replaceVars ./fix-glycin-paths.patch {
+      bwrap = "${bubblewrap}/bin/bwrap";
+    };
+
+    glycinDepsPatch = ./fix-glycin-deps.patch;
+  };
+
+  meta = with lib; {
+    description = "libglycin-gtk4 with vapi";
+    homepage = "https://gitlab.gnome.org/GNOME/glycin";
+    license = with licenses; [
+      mpl20 # or
+      lgpl21Plus
+    ];
+    platforms = platforms.linux;
+  };
+})


### PR DESCRIPTION
These provide sandboxed image loading. This should be working but hasn't been integrated with anything yet.